### PR TITLE
Add linked items element type

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "trackingHeader": {
     "header": "X-KC-SOURCE",
-    "value": "@kentico/kontent-schema-generator-graphql;2.0.0"
+    "value": "@kentico/kontent-schema-generator-graphql;2.1.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kentico/kontent-schema-generator-graphql",
-  "version": "2.0.0-rebranding.3",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kentico/kontent-schema-generator-graphql",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "GraphQL schema generator used to generate schema based on specified project.",
   "main": "_commonjs/index.js",
   "bin": {

--- a/src/__tests__/data/fakeEmptyTypes.output.gql
+++ b/src/__tests__/data/fakeEmptyTypes.output.gql
@@ -84,6 +84,12 @@ type RichTextElement {
   images: [RichTextImage]
   resolvedHtml: String
 }
+type LinkedItemsElement {
+  type: String!
+  name: String!
+  value: [ContentItem]
+  linkedItemCodenames: [String]
+}
 type CustomElement {
   type: String!
   name: String!

--- a/src/__tests__/data/fakeTypesComplex.output.gql
+++ b/src/__tests__/data/fakeTypesComplex.output.gql
@@ -84,6 +84,12 @@ type RichTextElement {
   images: [RichTextImage]
   resolvedHtml: String
 }
+type LinkedItemsElement {
+  type: String!
+  name: String!
+  value: [ContentItem]
+  linkedItemCodenames: [String]
+}
 type CustomElement {
   type: String!
   name: String!
@@ -104,7 +110,7 @@ type AboutUsContentType implements ContentItem {
   metadata__twitter_title: TextElement
   metadata__twitter_description: TextElement
   metadata__og_image: AssetElement
-  facts: [ContentItem]
+  facts: LinkedItemsElement
 }
 
 type AccessoryContentType implements ContentItem {
@@ -152,7 +158,7 @@ type ArticleContentType implements ContentItem {
   metadata__twitter_description: TextElement
   meta_description: TextElement
   metadata__og_image: AssetElement
-  related_articles: [ContentItem]
+  related_articles: LinkedItemsElement
   url_pattern: UrlSlugElement
 }
 
@@ -263,12 +269,12 @@ type HomeContentType implements ContentItem {
   metadata__og_description: TextElement
   metadata__meta_title: TextElement
   metadata__og_title: TextElement
-  articles: [ContentItem]
-  hero_unit: [ContentItem]
+  articles: LinkedItemsElement
+  hero_unit: LinkedItemsElement
   metadata__meta_description: TextElement
   metadata__twitter_site: TextElement
-  our_story: [ContentItem]
-  cafes: [ContentItem]
+  our_story: LinkedItemsElement
+  cafes: LinkedItemsElement
   metadata__twitter_image: AssetElement
   metadata__twitter_creator: TextElement
   metadata__twitter_title: TextElement

--- a/src/__tests__/e2e/__snapshots__/schema-generator.spec.ts.snap
+++ b/src/__tests__/e2e/__snapshots__/schema-generator.spec.ts.snap
@@ -87,6 +87,12 @@ type RichTextElement {
   images: [RichTextImage]
   resolvedHtml: String
 }
+type LinkedItemsElement {
+  type: String!
+  name: String!
+  value: [ContentItem]
+  linkedItemCodenames: [String]
+}
 type CustomElement {
   type: String!
   name: String!
@@ -107,7 +113,7 @@ type AboutUsContentType implements ContentItem {
   metadata__twitter_title: TextElement
   metadata__twitter_description: TextElement
   metadata__og_image: AssetElement
-  facts: [ContentItem]
+  facts: LinkedItemsElement
 }
 
 type AccessoryContentType implements ContentItem {
@@ -154,7 +160,7 @@ type ArticleContentType implements ContentItem {
   metadata__twitter_description: TextElement
   meta_description: TextElement
   metadata__og_image: AssetElement
-  related_articles: [ContentItem]
+  related_articles: LinkedItemsElement
   url_pattern: UrlSlugElement
 }
 
@@ -265,12 +271,12 @@ type HomeContentType implements ContentItem {
   metadata__og_description: TextElement
   metadata__meta_title: TextElement
   metadata__og_title: TextElement
-  articles: [ContentItem]
-  hero_unit: [ContentItem]
+  articles: LinkedItemsElement
+  hero_unit: LinkedItemsElement
   metadata__meta_description: TextElement
   metadata__twitter_site: TextElement
-  our_story: [ContentItem]
-  cafes: [ContentItem]
+  our_story: LinkedItemsElement
+  cafes: LinkedItemsElement
   metadata__twitter_image: AssetElement
   metadata__twitter_creator: TextElement
   metadata__twitter_title: TextElement

--- a/src/__tests__/unit/graphql-schema-model.spec.ts
+++ b/src/__tests__/unit/graphql-schema-model.spec.ts
@@ -4,6 +4,6 @@ describe('getFieldDefinitions ', () => {
   it('Return correct number of items', () => {
     const schemaModel = new GraphQLSchemaModel();
     const fieldSchemas = schemaModel.getFieldDefinitions();
-    expect(fieldSchemas.length).toEqual(16);
+    expect(fieldSchemas.length).toEqual(17);
   });
 });

--- a/src/graphql-schema-model.ts
+++ b/src/graphql-schema-model.ts
@@ -14,8 +14,7 @@ export class GraphQLSchemaModel {
   public static assetElementTypeName: string = 'AssetElement';
   public static richTextElementTypeName: string = 'RichTextElement';
   public static customElementTypeName: string = 'CustomElement';
-
-  public static linkedItemsElement: string = '[ContentItem]';
+  public static linkedItemsElement: string = 'LinkedItemsElement';
 
   public static elementTypeMapping: Map<string, string> = new Map([
     [
@@ -195,6 +194,15 @@ export class GraphQLSchemaModel {
   links: [Link]
   images: [RichTextImage]
   resolvedHtml: String
+}`,
+    ],
+    [
+      ElementType.ModularContent.toString(),
+      `type ${GraphQLSchemaModel.linkedItemsElement} {
+  type: String!
+  name: String!
+  value: [ContentItem]
+  linkedItemCodenames: [String]
 }`,
     ],
     [


### PR DESCRIPTION
### Motivation

fixes #18 

Added linked item element

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

testing was performed against https://github.com/Kentico/kontent-boilerplate-express-apollo on the article type and related articles.

with this query

```gql
{
  itemsByType(
    type: "article"
    limit: 3
    depth: 0
    order: "elements.post_date"
  ) {
    ... on ArticleContentType {
      title {
        value
      }
      related_articles {
        name
        type
        linkedItemCodenames
        value {
          ... on ArticleContentType {
            title {
              value
            }
          }
        }
      }
    }
  }
}

```